### PR TITLE
Fix `satori` broken on CommonJS

### DIFF
--- a/bin/satori.js
+++ b/bin/satori.js
@@ -1,8 +1,8 @@
-const satori = require('satori').default;
-const fs = require('fs');
-const parse = require('html-react-parser');
-
 (async () => {
+    const satori = (await import('satori')).default;
+    const fs = await import('fs');
+    const parse = (await import('html-react-parser')).default;
+
     const arguments = process.argv.slice(2);
 
     const htmlFilePath = arguments[0];


### PR DESCRIPTION
Since `satori@0.0.46`, the support on CommonJS was broken.

This PR changes all the `require()` to dynamic `import()` in `satori.js` bin, in order to fix the compatibility issue with the latest version of `satori`.